### PR TITLE
Fix issue cursor positioning issues

### DIFF
--- a/lib/TerminalDisplay.cpp
+++ b/lib/TerminalDisplay.cpp
@@ -291,6 +291,15 @@ void TerminalDisplay::setVTFont(const QFont& f)
   // Disabling kerning saves some computation when rendering text.
   font.setKerning(false);
 
+  // QFont::ForceIntegerMetrics has been removed.
+  // Set full hinting instead to ensure the letters are aligned properly.
+  font.setHintingPreference(QFont::PreferFullHinting);
+
+  // "Draw intense colors in bold font" feature needs to use different font weights. StyleName
+  // property, when set, doesn't allow weight changes. Since all properties (weight, stretch,
+  // italic, etc) are stored in QFont independently, in almost all cases styleName is not needed.
+  font.setStyleName(QString());
+
   QWidget::setFont(font);
   fontChange(font);
 }


### PR DESCRIPTION
Qt6 has removed `QFont::ForceIntegerMetrics` from `QFont`. This causes incorrect positioning of the cursor in the terminal, especially visible when the number of characters is large (typically > 30).

As an alternative, we can use `QFont::PreferFullHinting` to ensure all the letters are aligned properly.

Another of their fixes is for "intense colors", which is also included in this PR.

PS: I have taken this from Konsole's [TerminalFonts.cpp](https://invent.kde.org/utilities/konsole/-/blob/master/src/terminalDisplay/TerminalFonts.cpp?ref_type=heads#L81-88) file.